### PR TITLE
Business hours respecting seconds

### DIFF
--- a/src/Business.php
+++ b/src/Business.php
@@ -140,7 +140,7 @@ final class Business implements BusinessInterface, \Serializable
 
         if (!$this->holidays->isHoliday($tmpDate) && null !== $day = $this->getDay($dayOfWeek)) {
             if (null !== $closestTime = $day->getClosestOpeningTimeBefore($time, $tmpDate)) {
-                $tmpDate->setTime($closestTime->getHours(), $closestTime->getMinutes());
+                $tmpDate->setTime($closestTime->getHours(), $closestTime->getMinutes(), $closestTime->getSeconds());
 
                 return $tmpDate;
             }
@@ -154,7 +154,7 @@ final class Business implements BusinessInterface, \Serializable
 
         $closestDay = $this->getClosestDayBefore((int) $tmpDate->format('N'));
         $closingTime = $closestDay->getClosingTime($tmpDate);
-        $tmpDate->setTime($closingTime->getHours(), $closingTime->getMinutes());
+        $tmpDate->setTime($closingTime->getHours(), $closingTime->getMinutes(), $closingTime->getSeconds());
 
         return $tmpDate;
     }
@@ -196,7 +196,7 @@ final class Business implements BusinessInterface, \Serializable
 
         if (!$this->holidays->isHoliday($tmpDate) && null !== $day = $this->getDay($dayOfWeek)) {
             if (null !== $closestTime = $day->getClosestOpeningTimeAfter($time, $tmpDate)) {
-                $tmpDate->setTime($closestTime->getHours(), $closestTime->getMinutes());
+                $tmpDate->setTime($closestTime->getHours(), $closestTime->getMinutes(), $closestTime->getSeconds());
 
                 return $tmpDate;
             }
@@ -210,7 +210,7 @@ final class Business implements BusinessInterface, \Serializable
 
         $closestDay = $this->getClosestDayBefore((int) $tmpDate->format('N'));
         $closingTime = $closestDay->getOpeningTime($tmpDate);
-        $tmpDate->setTime($closingTime->getHours(), $closingTime->getMinutes());
+        $tmpDate->setTime($closingTime->getHours(), $closingTime->getMinutes(), $closingTime->getSeconds());
 
         return $tmpDate;
     }

--- a/src/Time.php
+++ b/src/Time.php
@@ -25,15 +25,15 @@ final class Time
     /**
      * Creates a new time.
      *
-     * @param string $hours
-     * @param string $minutes
-     * @param string $seconds Optional seconds with leading zero
+     * @param string|int $hours
+     * @param string|int $minutes
+     * @param string|int $seconds Optional seconds
      */
-    public function __construct($hours, $minutes, $seconds = '00')
+    public function __construct($hours, $minutes, $seconds = 0)
     {
-        $this->hours = $hours;
-        $this->minutes = $minutes;
-        $this->seconds = $seconds;
+        $this->hours = (int) $hours;
+        $this->minutes = (int) $minutes;
+        $this->seconds = (int) $seconds;
     }
 
     /**
@@ -99,7 +99,7 @@ final class Time
      */
     public function getHours()
     {
-        return (int) $this->hours;
+        return $this->hours;
     }
 
     /**
@@ -109,7 +109,7 @@ final class Time
      */
     public function getMinutes()
     {
-        return (int) $this->minutes;
+        return $this->minutes;
     }
 
     /**
@@ -119,7 +119,7 @@ final class Time
      */
     public function getSeconds()
     {
-        return (int) $this->seconds;
+        return $this->seconds;
     }
 
     /**
@@ -129,7 +129,7 @@ final class Time
      */
     public function toInteger()
     {
-        return (int) $this->hours.$this->minutes.$this->seconds;
+        return (int) sprintf('%d%02d%02d', $this->hours, $this->minutes, $this->seconds);
     }
 
     /**
@@ -139,6 +139,6 @@ final class Time
      */
     public function toString()
     {
-        return sprintf('%s:%s:%s', $this->hours, $this->minutes, $this->seconds);
+        return sprintf('%02d:%02d:%02d', $this->hours, $this->minutes, $this->seconds);
     }
 }

--- a/src/Time.php
+++ b/src/Time.php
@@ -20,17 +20,20 @@ final class Time
 {
     private $hours;
     private $minutes;
+    private $seconds;
 
     /**
      * Creates a new time.
      *
      * @param string $hours
      * @param string $minutes
+     * @param string $seconds Optional seconds with leading zero
      */
-    public function __construct($hours, $minutes)
+    public function __construct($hours, $minutes, $seconds = '00')
     {
         $this->hours = $hours;
         $this->minutes = $minutes;
+        $this->seconds = $seconds;
     }
 
     /**
@@ -62,7 +65,7 @@ final class Time
      */
     public static function fromDate(\DateTime $date)
     {
-        return new self($date->format('H'), $date->format('i'));
+        return new self($date->format('H'), $date->format('i'), $date->format('s'));
     }
 
     /**
@@ -110,13 +113,23 @@ final class Time
     }
 
     /**
+     * Gets the seconds.
+     *
+     * @return int
+     */
+    public function getSeconds()
+    {
+        return (int) $this->seconds;
+    }
+
+    /**
      * Returns an integer representation of the time.
      *
      * @return integer
      */
     public function toInteger()
     {
-        return (int) $this->hours.$this->minutes;
+        return (int) $this->hours.$this->minutes.$this->seconds;
     }
 
     /**
@@ -126,6 +139,6 @@ final class Time
      */
     public function toString()
     {
-        return sprintf('%s:%s', $this->hours, $this->minutes);
+        return sprintf('%s:%s:%s', $this->hours, $this->minutes, $this->seconds);
     }
 }

--- a/tests/BusinessTest.php
+++ b/tests/BusinessTest.php
@@ -34,6 +34,7 @@ class BusinessTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse($business->within(new \DateTime('2015-05-11 18:00'))); // Monday
         $this->assertFalse($business->within(new \DateTime('2015-05-12 10:00'))); // Tuesday
+        $this->assertFalse($business->within(new \DateTime('2015-05-11 13:00:25'))); // Monday, seconds outside business hours
     }
 
     public function testWithinWithHoliday()
@@ -356,6 +357,26 @@ class BusinessTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('2015-05-29 10:00', $dates[1]->format('Y-m-d H:i'));
         $this->assertEquals('2015-06-01 09:00', $dates[2]->format('Y-m-d H:i'));
         $this->assertEquals('2015-06-05 10:00', $dates[3]->format('Y-m-d H:i'));
+    }
+
+    public function testTimelineWithSeconds()
+    {
+        $business = new Business([
+            new Day(Days::MONDAY, [['09:00', '17:00']]),
+            new Day(Days::TUESDAY, [['09:00', '17:00']]),
+            new Day(Days::WEDNESDAY, [['09:00', '17:00']]),
+        ]);
+
+        $start = new \DateTime('2015-05-25 11:00:25'); // Monday, with seconds
+        $end = new \DateTime('2015-05-27 13:00:40');
+
+        $dates = $business->timeline($start, $end, new \DateInterval('P1D'));
+
+        $this->assertCount(3, $dates);
+
+        $this->assertEquals('2015-05-25 11:00:25', $dates[0]->format('Y-m-d H:i:s'));
+        $this->assertEquals('2015-05-26 11:00:25', $dates[1]->format('Y-m-d H:i:s'));
+        $this->assertEquals('2015-05-27 11:00:25', $dates[2]->format('Y-m-d H:i:s'));
     }
 
     public function testTimelineWithDaysIntervalAndHolidays()

--- a/tests/TimeIntervalTest.php
+++ b/tests/TimeIntervalTest.php
@@ -18,7 +18,7 @@ class TimeIntervalTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The opening time "08:00" must be before the closing time "08:00".
+     * @expectedExceptionMessage The opening time "08:00:00" must be before the closing time "08:00:00".
      */
     public function testConstructorOpeningEqualClosing()
     {
@@ -27,7 +27,7 @@ class TimeIntervalTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The opening time "18:00" must be before the closing time "08:00".
+     * @expectedExceptionMessage The opening time "18:00:00" must be before the closing time "08:00:00".
      */
     public function testConstructorOpeningAfterClosing()
     {

--- a/tests/TimeTest.php
+++ b/tests/TimeTest.php
@@ -67,5 +67,9 @@ class TimeTest extends \PHPUnit_Framework_TestCase
     {
         $time = new Time('20', '30');
         $this->assertEquals('20:30:00', $time->toString());
+        $time = new Time('9', '8', '7');
+        $this->assertEquals('09:08:07', $time->toString());
+        $time = new Time(9, 8, 7);
+        $this->assertEquals('09:08:07', $time->toString());
     }
 }

--- a/tests/TimeTest.php
+++ b/tests/TimeTest.php
@@ -41,10 +41,10 @@ class TimeTest extends \PHPUnit_Framework_TestCase
     public function testToInteger()
     {
         $time = new Time('20', '00');
-        $this->assertEquals(2000, $time->toInteger());
+        $this->assertEquals(200000, $time->toInteger());
 
         $time = new Time('09', '30');
-        $this->assertEquals(930, $time->toInteger());
+        $this->assertEquals(93000, $time->toInteger());
     }
 
     public function testIsAfterOrEqual()
@@ -66,6 +66,6 @@ class TimeTest extends \PHPUnit_Framework_TestCase
     public function testToString()
     {
         $time = new Time('20', '30');
-        $this->assertEquals('20:30', $time->toString());
+        $this->assertEquals('20:30:00', $time->toString());
     }
 }


### PR DESCRIPTION
Start and end times can have seconds other then zero.

Currently seconds were ignored, having two problems:
- End can be n seconds after closing time, currently it is incorrectly counted as being within office hours
- We need to calculate seconds within business hours, but seconds on starting time are ignored

This PR solves both problems. Changes are backwards compatible, except for `toInteger()` and `toString()` methods on the `Time` class

One additional improvement included in this PR, is not to force leading zeros on Time class and allow for integers being passed in.