### PR TITLE
Fix within method behavior

### DIFF
--- a/src/Time.php
+++ b/src/Time.php
@@ -91,6 +91,18 @@ final class Time implements \JsonSerializable
     {
         return $this->toInteger() >= $other->toInteger();
     }
+    
+    /**
+     * Checks if this time is after or equal to an other time.
+     *
+     * @param Time $other
+     *
+     * @return bool
+     */
+    public function isAfter(Time $other)
+    {
+        return $this->toInteger() > $other->toInteger();
+    }
 
     /**
      * Gets the hours.

--- a/src/TimeInterval.php
+++ b/src/TimeInterval.php
@@ -67,7 +67,7 @@ final class TimeInterval implements \JsonSerializable
      */
     public function contains(Time $time)
     {
-        return $this->start->isBeforeOrEqual($time) && $this->end->isAfterOrEqual($time);
+        return $this->start->isBeforeOrEqual($time) && $this->end->isAfter($time);
     }
 
     /**


### PR DESCRIPTION
This slightly modifies the behavior of the `within` method.

Currently when your closing time is 17:00 and the current time is exactly 17:00, the `within` method will return true, or 'is open', where you would expect it to be closed, because the business closes at 17.00 not 17.01.

This PR fixes that.